### PR TITLE
✨  Make CUE templates work without 'out'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ spec:
     batchModeProcessing: true
     data: | #cue
       _unique_groups_map: {
-        for result in data {
+        for result in DATA {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ spec:
     language: cue
     batchModeProcessing: true
     data: | #cue
-      unique_groups_map: {
+      _unique_groups_map: {
         for result in data {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }
-      unique_groups: [ for g in unique_groups_map {g}]
-      out: {
+      _unique_groups: [ for g in _unique_groups_map {g}]
+      {
         apiVersion: "rbac.authorization.k8s.io/v1"
         kind: "ClusterRole"
         metadata: 
           name: "crossplane-aws-readers-role"
         rules: [
             {
-              apiGroups: unique_groups
+              apiGroups: _unique_groups
               resources: "*"
               verbs: ["get", "list", "watch"]
             }

--- a/examples/aws-auth/input/templates/aws-auth.yaml
+++ b/examples/aws-auth/input/templates/aws-auth.yaml
@@ -17,8 +17,8 @@ spec:
     data: | #cue
       import "strings"
 
-      mapRoles: strings.Join([for result in data {result.cm.data.mapRoles}], "")
-      out: {
+      _mapRoles: strings.Join([for result in data {result.cm.data.mapRoles}], "")
+      {
         apiVersion: "v1"
         kind: "ConfigMap"
         metadata: {
@@ -26,6 +26,6 @@ spec:
           namespace: "kube-system"
         }
         data: {
-          "mapRoles": mapRoles
+          "mapRoles": _mapRoles
         }
       }

--- a/examples/aws-auth/input/templates/aws-auth.yaml
+++ b/examples/aws-auth/input/templates/aws-auth.yaml
@@ -17,15 +17,15 @@ spec:
     data: | #cue
       import "strings"
 
-      _mapRoles: strings.Join([for result in data {result.cm.data.mapRoles}], "")
-      {
-        apiVersion: "v1"
-        kind: "ConfigMap"
-        metadata: {
-          name: "aws-auth"
-          namespace: "kube-system"
-        }
-        data: {
-          "mapRoles": _mapRoles
-        }
+      _mapRoles: strings.Join([for result in DATA {result.cm.data.mapRoles}], "")
+
+      apiVersion: "v1"
+      kind: "ConfigMap"
+      metadata: {
+        name: "aws-auth"
+        namespace: "kube-system"
       }
+      data: {
+        "mapRoles": _mapRoles
+      }
+

--- a/examples/aws-auth/readme.md
+++ b/examples/aws-auth/readme.md
@@ -78,7 +78,7 @@ spec:
     data: | #cue
       import "strings"
 
-      _mapRoles: strings.Join([for result in data {result.cm.data.mapRoles}], "")
+      _mapRoles: strings.Join([for result in DATA {result.cm.data.mapRoles}], "")
       {
         apiVersion: "v1"
         kind: "ConfigMap"

--- a/examples/aws-auth/readme.md
+++ b/examples/aws-auth/readme.md
@@ -78,8 +78,8 @@ spec:
     data: | #cue
       import "strings"
 
-      mapRoles: strings.Join([for result in data {result.cm.data.mapRoles}], "")
-      out: {
+      _mapRoles: strings.Join([for result in data {result.cm.data.mapRoles}], "")
+      {
         apiVersion: "v1"
         kind: "ConfigMap"
         metadata: {
@@ -87,7 +87,7 @@ spec:
           namespace: "kube-system"
         }
         data: {
-          "mapRoles": mapRoles
+          "mapRoles": _mapRoles
         }
       }
 ```

--- a/examples/extending-rbac/input/templates/generate_role.yaml
+++ b/examples/extending-rbac/input/templates/generate_role.yaml
@@ -15,23 +15,23 @@ spec:
       ./output/out.yaml
     data: | #cue
       _unique_groups_map: {
-        for result in data {
+        for result in DATA {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }
       _unique_groups: [ for g in _unique_groups_map {g}]
-      {
-        apiVersion: "rbac.authorization.k8s.io/v1"
-        kind: "ClusterRole"
-        metadata:
-          name: "crossplane-aws-readers-role"
-        rules: [
-            {
-              apiGroups: _unique_groups
-              resources: [
-                  "*"
-              ]
-              verbs: ["get", "list", "watch"]
-            }
-        ]
-      }
+
+      apiVersion: "rbac.authorization.k8s.io/v1"
+      kind: "ClusterRole"
+      metadata:
+        name: "crossplane-aws-readers-role"
+      rules: [
+          {
+            apiGroups: _unique_groups
+            resources: [
+                "*"
+            ]
+            verbs: ["get", "list", "watch"]
+          }
+      ]
+

--- a/examples/extending-rbac/input/templates/generate_role.yaml
+++ b/examples/extending-rbac/input/templates/generate_role.yaml
@@ -14,20 +14,20 @@ spec:
     fileName: |
       ./output/out.yaml
     data: | #cue
-      unique_groups_map: {
+      _unique_groups_map: {
         for result in data {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }
-      unique_groups: [ for g in unique_groups_map {g}]
-      out: {
+      _unique_groups: [ for g in _unique_groups_map {g}]
+      {
         apiVersion: "rbac.authorization.k8s.io/v1"
         kind: "ClusterRole"
         metadata:
           name: "crossplane-aws-readers-role"
         rules: [
             {
-              apiGroups: unique_groups
+              apiGroups: _unique_groups
               resources: [
                   "*"
               ]

--- a/examples/extending-rbac/readme.md
+++ b/examples/extending-rbac/readme.md
@@ -26,7 +26,7 @@ spec:
     batchModeProcessing: true
     data: | #cue
       _unique_groups_map: {
-        for result in data {
+        for result in DATA {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }

--- a/examples/extending-rbac/readme.md
+++ b/examples/extending-rbac/readme.md
@@ -25,20 +25,20 @@ spec:
     language: cue
     batchModeProcessing: true
     data: | #cue
-      unique_groups_map: {
+      _unique_groups_map: {
         for result in data {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }
-      unique_groups: [ for g in unique_groups_map {g}]
-      out: {
+      _unique_groups: [ for g in _unique_groups_map {g}]
+      {
         apiVersion: "rbac.authorization.k8s.io/v1"
         kind: "ClusterRole"
         metadata: 
           name: "crossplane-aws-readers-role"
         rules: [
             {
-              apiGroups: unique_groups
+              apiGroups: _unique_groups
               resources: "*"
               verbs: ["get", "list", "watch"]
             }

--- a/internal/controller/test_resources/delete_scenario/input/templates/test_template.yaml
+++ b/internal/controller/test_resources/delete_scenario/input/templates/test_template.yaml
@@ -15,18 +15,12 @@ spec:
     fileName: |
       ./output/out.yaml
     data: | #cue
-      let DATA = data
-      {
-            apiVersion: "v1"
-            kind: "ConfigMap"
-            metadata: {
-              name: "test-\(DATA.cm.metadata.name)"
-              namespace: "kube-system"
-            }
-            data: {
-              "mapRoles": DATA.cm.data.mapRoles
-            }
+      apiVersion: "v1"
+      kind: "ConfigMap"
+      metadata: {
+        name: "test-\(DATA.cm.metadata.name)"
+        namespace: "kube-system"
       }
-
-
-
+      data: {
+        "mapRoles": DATA.cm.data.mapRoles
+      }

--- a/internal/controller/test_resources/delete_scenario/input/templates/test_template.yaml
+++ b/internal/controller/test_resources/delete_scenario/input/templates/test_template.yaml
@@ -16,7 +16,7 @@ spec:
       ./output/out.yaml
     data: | #cue
       let DATA = data
-      out: {
+      {
             apiVersion: "v1"
             kind: "ConfigMap"
             metadata: {

--- a/renderer/cue/cuetemplate.go
+++ b/renderer/cue/cuetemplate.go
@@ -47,7 +47,7 @@ func (r *CUERenderer) Render(results any, output *renderer.Output) error {
 }
 
 func (t *CUERenderer) evaluate(r any, o *renderer.Output) error {
-	data := t.ctx.Encode(map[string]any{"data": r})
+	data := t.ctx.Encode(map[string]any{"DATA": r})
 	compiled := t.ctx.CompileString(t.config, cuelang.Scope(data))
 	v := compiled.Eval()
 

--- a/renderer/cue/cuetemplate_test.go
+++ b/renderer/cue/cuetemplate_test.go
@@ -36,7 +36,7 @@ func TestRenderCUEImportStrings(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
 	import "strings"
 
-	out: {
+	{
 		foo: strings.Join(["a", "b"], "-")
 	}`, t.Name())
 	require.NoError(t, err)
@@ -66,8 +66,7 @@ func getTestResource(t *testing.T, name string) repository.Resource {
 
 func TestRenderCUEWithBatchModeProcessingOffWithSingleResourceOutput(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
-	out: 
-		foo: data.a.metadata.name
+	foo: data.a.metadata.name
 	`, t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
@@ -95,7 +94,7 @@ func TestRenderCUEWithBatchModeProcessingOffWithSingleResourceOutput(t *testing.
 
 func TestRenderCUEWithBatchModeProcessingOffWithMultipleResourcesOutput(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
-	out: [
+	[
 		{
 			foo: data.a.metadata.name
 		},
@@ -130,7 +129,7 @@ func TestRenderCUEWithBatchModeProcessingOffWithMultipleResourcesOutput(t *testi
 
 func TestRenderCUEWithBatchModeProcessingOnWithMultipleResourcesOutput(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
-	out: [
+	[
 		for result in data {
 		foo: result.a.metadata.name
 		}
@@ -157,7 +156,7 @@ func TestRenderCUEWithBatchModeProcessingOnWithMultipleResourcesOutput(t *testin
 
 func TestRenderCUEWithBatchModeProcessingOnWithSingleResourceOutput(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
-	out: {
+	{
 		foos: [
 			for result in data {
 				foo: result.a.metadata.name
@@ -186,7 +185,7 @@ func TestRenderCUEWithBatchModeProcessingOnWithSingleResourceOutput(t *testing.T
 
 func TestErrorUnknownVariableReference(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
-	out: {
+	{
 		foo: errrrrr
 	}`, t.Name())
 	require.NoError(t, err)
@@ -198,13 +197,13 @@ func TestErrorUnknownVariableReference(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "error evaluating CUE template")
 		assert.ErrorContains(t, err, "[line 3, column 8]")
-		assert.ErrorContains(t, err, "out.foo: reference \"errrrrr\" not found")
+		assert.ErrorContains(t, err, "foo: reference \"errrrrr\" not found")
 
 		var rerr *renderer.Error
 		require.ErrorAs(t, err, &rerr)
 		assert.EqualValues(t, 3, rerr.Line())
 		assert.EqualValues(t, 8, rerr.Column())
-		assert.ErrorContains(t, rerr, "out.foo: reference \"errrrrr\" not found")
+		assert.ErrorContains(t, rerr, "foo: reference \"errrrrr\" not found")
 	})
 
 	t.Run("BatchModeOff", func(t *testing.T) {
@@ -217,18 +216,18 @@ func TestErrorUnknownVariableReference(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "error evaluating CUE template")
 		assert.ErrorContains(t, err, "[line 3, column 8]")
-		assert.ErrorContains(t, err, "out.foo: reference \"errrrrr\" not found")
+		assert.ErrorContains(t, err, "foo: reference \"errrrrr\" not found")
 
 		var rerr *renderer.Error
 		require.ErrorAs(t, err, &rerr)
 		assert.EqualValues(t, 3, rerr.Line())
 		assert.EqualValues(t, 8, rerr.Column())
-		assert.ErrorContains(t, rerr, "out.foo: reference \"errrrrr\" not found")
+		assert.ErrorContains(t, rerr, "foo: reference \"errrrrr\" not found")
 	})
 }
 
 func TestErrorBadlyFormed(t *testing.T) {
-	tpl, err := cue.NewCUERenderer(`out: {`, t.Name())
+	tpl, err := cue.NewCUERenderer(`{`, t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
 
@@ -238,15 +237,13 @@ func TestErrorBadlyFormed(t *testing.T) {
 
 	var rerr *renderer.Error
 	require.ErrorAs(t, err, &rerr)
-	assert.EqualValues(t, 3, rerr.Line())
-	assert.EqualValues(t, 10, rerr.Column())
+	assert.EqualValues(t, 1, rerr.Line())
+	assert.EqualValues(t, 2, rerr.Column())
 	assert.ErrorContains(t, err, "expected '}'")
 }
 
 func TestErrorNoOutput(t *testing.T) {
-	tpl, err := cue.NewCUERenderer(`x: {
-	foo: "bar"
-}`, t.Name())
+	tpl, err := cue.NewCUERenderer(`"s" | 42`, t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
 
@@ -259,18 +256,18 @@ func TestErrorNoOutput(t *testing.T) {
 	t.Run("BatchModeOn", func(t *testing.T) {
 		_, err = renderer.Render(tpl, results, true)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "'out' is not set to anything concrete")
+		assert.ErrorContains(t, err, "output is nothing concrete")
 	})
 
 	t.Run("BatchModeOff", func(t *testing.T) {
 		_, err = renderer.Render(tpl, results, false)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "'out' is not set to anything concrete")
+		assert.ErrorContains(t, err, "output is nothing concrete")
 	})
 }
 
 func TestErrorUnsupportedOutputType(t *testing.T) {
-	tpl, err := cue.NewCUERenderer(`out: 42`, t.Name())
+	tpl, err := cue.NewCUERenderer(`42`, t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
 
@@ -283,18 +280,18 @@ func TestErrorUnsupportedOutputType(t *testing.T) {
 	t.Run("BatchModeOn", func(t *testing.T) {
 		_, err = renderer.Render(tpl, results, true)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "'out' has unsupported output type 'int'")
+		assert.ErrorContains(t, err, "output is unsupported type 'int'")
 	})
 
 	t.Run("BatchModeOff", func(t *testing.T) {
 		_, err = renderer.Render(tpl, results, false)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "'out' has unsupported output type 'int'")
+		assert.ErrorContains(t, err, "output is unsupported type 'int'")
 	})
 }
 
 func TestErrorMismatchedOutputType(t *testing.T) {
-	renderToList, err := cue.NewCUERenderer(`out: [42]`, t.Name())
+	renderToList, err := cue.NewCUERenderer(`[42]`, t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, renderToList)
 
@@ -307,12 +304,12 @@ func TestErrorMismatchedOutputType(t *testing.T) {
 	t.Run("BatchModeOn", func(t *testing.T) {
 		_, err := renderer.Render(renderToList, results, true)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "error decoding 'out'")
+		assert.ErrorContains(t, err, "error decoding output")
 	})
 
 	t.Run("BatchModeOff", func(t *testing.T) {
 		_, err := renderer.Render(renderToList, results, false)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "error decoding 'out'")
+		assert.ErrorContains(t, err, "error decoding output")
 	})
 }

--- a/renderer/cue/cuetemplate_test.go
+++ b/renderer/cue/cuetemplate_test.go
@@ -18,8 +18,8 @@ func TestNewCUERenderer(t *testing.T) {
 
 func TestRenderCUEWithEmptyResources(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
-	out: [
-        for result in data {
+	[
+        for result in DATA {
 			foo: "bar"
 		}
 	]`, t.Name())
@@ -36,9 +36,7 @@ func TestRenderCUEImportStrings(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
 	import "strings"
 
-	{
-		foo: strings.Join(["a", "b"], "-")
-	}`, t.Name())
+	foo: strings.Join(["a", "b"], "-")`, t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
 
@@ -66,7 +64,7 @@ func getTestResource(t *testing.T, name string) repository.Resource {
 
 func TestRenderCUEWithBatchModeProcessingOffWithSingleResourceOutput(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
-	foo: data.a.metadata.name
+	foo: DATA.a.metadata.name
 	`, t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
@@ -96,10 +94,10 @@ func TestRenderCUEWithBatchModeProcessingOffWithMultipleResourcesOutput(t *testi
 	tpl, err := cue.NewCUERenderer(`
 	[
 		{
-			foo: data.a.metadata.name
+			foo: DATA.a.metadata.name
 		},
 		{
-			bar: data.a.metadata.name
+			bar: DATA.a.metadata.name
 		}
 	]
 	`, t.Name())
@@ -130,8 +128,8 @@ func TestRenderCUEWithBatchModeProcessingOffWithMultipleResourcesOutput(t *testi
 func TestRenderCUEWithBatchModeProcessingOnWithMultipleResourcesOutput(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
 	[
-		for result in data {
-		foo: result.a.metadata.name
+		for result in DATA {
+			foo: result.a.metadata.name
 		}
 	]`, t.Name())
 	require.NoError(t, err)
@@ -156,13 +154,11 @@ func TestRenderCUEWithBatchModeProcessingOnWithMultipleResourcesOutput(t *testin
 
 func TestRenderCUEWithBatchModeProcessingOnWithSingleResourceOutput(t *testing.T) {
 	tpl, err := cue.NewCUERenderer(`
-	{
-		foos: [
-			for result in data {
-				foo: result.a.metadata.name
-			}
-		]
-	}`, t.Name())
+	foos: [
+		for result in DATA {
+			foo: result.a.metadata.name
+		}
+	]`, t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
 

--- a/test/resources/extending-rbac/input/templates/generate_role.yaml
+++ b/test/resources/extending-rbac/input/templates/generate_role.yaml
@@ -15,23 +15,22 @@ spec:
       ./output/out.yaml
     data: | #cue
       _unique_groups_map: {
-        for result in data {
+        for result in DATA {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }
       _unique_groups: [ for g in _unique_groups_map {g}]
-      {
-        apiVersion: "rbac.authorization.k8s.io/v1"
-        kind: "ClusterRole"
-        metadata:
-          name: "crossplane-aws-readers-role"
-        rules: [
-            {
-              apiGroups: _unique_groups
-              resources: [
-                  "*"
-              ]
-              verbs: ["get", "list", "watch"]
-            }
-        ]
-      }
+
+      apiVersion: "rbac.authorization.k8s.io/v1"
+      kind: "ClusterRole"
+      metadata:
+        name: "crossplane-aws-readers-role"
+      rules: [
+          {
+            apiGroups: _unique_groups
+            resources: [
+                "*"
+            ]
+            verbs: ["get", "list", "watch"]
+          }
+      ]

--- a/test/resources/extending-rbac/input/templates/generate_role.yaml
+++ b/test/resources/extending-rbac/input/templates/generate_role.yaml
@@ -14,20 +14,20 @@ spec:
     fileName: |
       ./output/out.yaml
     data: | #cue
-      unique_groups_map: {
+      _unique_groups_map: {
         for result in data {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }
-      unique_groups: [ for g in unique_groups_map {g}]
-      out: {
+      _unique_groups: [ for g in _unique_groups_map {g}]
+      {
         apiVersion: "rbac.authorization.k8s.io/v1"
         kind: "ClusterRole"
         metadata:
           name: "crossplane-aws-readers-role"
         rules: [
             {
-              apiGroups: unique_groups
+              apiGroups: _unique_groups
               resources: [
                   "*"
               ]

--- a/test/resources/extending-rbac/readme.md
+++ b/test/resources/extending-rbac/readme.md
@@ -25,20 +25,20 @@ spec:
     language: cue
     batchModeProcessing: true
     data: | #cue
-      unique_groups_map: {
+      _unique_groups_map: {
         for result in data {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }
-      unique_groups: [ for g in unique_groups_map {g}]
-      out: {
+      _unique_groups: [ for g in _unique_groups_map {g}]
+      {
         apiVersion: "rbac.authorization.k8s.io/v1"
         kind: "ClusterRole"
         metadata: 
           name: "crossplane-aws-readers-role"
         rules: [
             {
-              apiGroups: unique_groups
+              apiGroups: _unique_groups
               resources: "*"
               verbs: ["get", "list", "watch"]
             }

--- a/test/resources/extending-rbac/readme.md
+++ b/test/resources/extending-rbac/readme.md
@@ -26,24 +26,23 @@ spec:
     batchModeProcessing: true
     data: | #cue
       _unique_groups_map: {
-        for result in data {
+        for result in DATA {
           "\(result.crd.spec.group)": result.crd.spec.group
         }
       }
       _unique_groups: [ for g in _unique_groups_map {g}]
-      {
-        apiVersion: "rbac.authorization.k8s.io/v1"
-        kind: "ClusterRole"
-        metadata: 
-          name: "crossplane-aws-readers-role"
-        rules: [
-            {
-              apiGroups: _unique_groups
-              resources: "*"
-              verbs: ["get", "list", "watch"]
-            }
-        ]
-      }
+
+      apiVersion: "rbac.authorization.k8s.io/v1"
+      kind: "ClusterRole"
+      metadata: 
+        name: "crossplane-aws-readers-role"
+      rules: [
+          {
+            apiGroups: _unique_groups
+            resources: "*"
+            verbs: ["get", "list", "watch"]
+          }
+      ]
 ```
 
 The expected output depends on which Crossplane AWS providers are installed, but should be roughly like this:


### PR DESCRIPTION
Also simplified CUE error position logic.

Note that it won't be necessary to put the template output in `out` anymore; just make the top-level output equal to whatever you need. If you need temporary variables, use private variables starting with `_`.